### PR TITLE
Driver jwlee 20171126

### DIFF
--- a/lib/EnsoCollectionsLib.py
+++ b/lib/EnsoCollectionsLib.py
@@ -30,12 +30,12 @@ def defCollection(MC=True):
                 },
                 'EnsoAlphaSwr': {
                     'variables': ['sst','swr'],
-                    'regions': {'sst': 'nino3', 'taux': 'nino4'},
+                    'regions': {'sst': 'nino3', 'swr': 'nino3'},
                     'obs_name': {'sst': ['HadISST1.1', 'OISST'], 'taux': ['Tropflux','ERA-Interim']},
                 },
                 'EnsoMu': {
                     'variables': ['sst', 'taux'],
-                    'regions': {'sst': 'nino3', 'swr': 'nino3'},
+                    'regions': {'sst': 'nino3', 'taux': 'nino4'},
                     'obs_name': {'sst': ['HadISST1.1', 'OISST'], 'taux': ['Tropflux', 'ERA-Interim']},
                 },
             },

--- a/lib/EnsoCollectionsLib.py
+++ b/lib/EnsoCollectionsLib.py
@@ -28,12 +28,12 @@ def defCollection(MC=True):
                     'regions': {'sst': 'tropical_pacific'},
                     'obs_name': {'sst': ['HadISST1.1', 'OISST']},
                 },
-                'EnsoMu': {
+                'EnsoAlphaSwr': {
                     'variables': ['sst','swr'],
                     'regions': {'sst': 'nino3', 'taux': 'nino4'},
                     'obs_name': {'sst': ['HadISST1.1', 'OISST'], 'taux': ['Tropflux','ERA-Interim']},
                 },
-                'EnsoAlphaSwr': {
+                'EnsoMu': {
                     'variables': ['sst', 'taux'],
                     'regions': {'sst': 'nino3', 'swr': 'nino3'},
                     'obs_name': {'sst': ['HadISST1.1', 'OISST'], 'taux': ['Tropflux', 'ERA-Interim']},

--- a/lib/EnsoCollectionsLib.py
+++ b/lib/EnsoCollectionsLib.py
@@ -57,7 +57,7 @@ def defCollection(MC=True):
 # List of metrics requirements (var name and reference obs)
 # def metricReqs(VOR=True):
 #     var_obs_requirements = {
-#         'EnsoAlpha': {'nbvar': 2, 'var_names': ['sst', 'thf'], 'ref_obs': ['Tropflux', 'Tropflux']},
+#         'EnsoAlphaThf': {'nbvar': 2, 'var_names': ['sst', 'thf'], 'ref_obs': ['Tropflux', 'Tropflux']},
 #         'EnsoAlphaLhf': {'nbvar': 2, 'var_names': ['sst', 'lhf'], 'ref_obs': ['Tropflux', 'Tropflux']},
 #         'EnsoAlphaLwr': {'nbvar': 2, 'var_names': ['sst', 'lwr'], 'ref_obs': ['Tropflux', 'Tropflux']},
 #         'EnsoAlphaSwr': {'nbvar': 2, 'var_names': ['sst', 'swr'], 'ref_obs': ['Tropflux', 'Tropflux']},

--- a/lib/EnsoCollectionsLib.py
+++ b/lib/EnsoCollectionsLib.py
@@ -31,7 +31,7 @@ def defCollection(MC=True):
                 'EnsoAlphaSwr': {
                     'variables': ['sst','swr'],
                     'regions': {'sst': 'nino3', 'swr': 'nino3'},
-                    'obs_name': {'sst': ['HadISST1.1', 'OISST'], 'taux': ['Tropflux','ERA-Interim']},
+                    'obs_name': {'sst': ['HadISST1.1', 'OISST'], 'swr': ['Tropflux','Tropflux']},
                 },
                 'EnsoMu': {
                     'variables': ['sst', 'taux'],

--- a/lib/EnsoMetricsLib.py
+++ b/lib/EnsoMetricsLib.py
@@ -280,7 +280,7 @@ def EnsoAlphaSwr(sstfile, swrfile, sstname, swrname, sstbox, swrbox, timebounds=
 
 def EnsoAlphaThf(sstfile, thffile, sstname, thfname, sstbox, thfbox, timebounds=None, frequency=None, mintimesteps=None):
     """
-    The EnsoAlpha() function computes the regression of 'thfbox' thfA (total heat flux anomalies) over 'sstbox' sstA
+    The EnsoAlphaThf() function computes the regression of 'thfbox' thfA (total heat flux anomalies) over 'sstbox' sstA
     (usually the regression of nino3 thfA over nino3 sstA)
     The total heat flux is the sum of four term:
          - net surface shortwave radiation,
@@ -734,7 +734,7 @@ dict_oneVar_modelAndObs = {'EnsoRMSE': EnsoRMSE,
 dict_oneVar = {'EnsoAmpl': EnsoAmpl, 'EnsoSeasonality': EnsoSeasonality,
                }
 
-dict_twoVar = {'EnsoAlpha': EnsoAlpha, 'EnsoAlphaLhf': EnsoAlphaLhf, 'EnsoAlphaLwr': EnsoAlphaLwr,
+dict_twoVar = {'EnsoAlphaThf': EnsoAlphaThf, 'EnsoAlphaLhf': EnsoAlphaLhf, 'EnsoAlphaLwr': EnsoAlphaLwr,
                'EnsoAlphaSwr': EnsoAlphaSwr, 'EnsoMu': EnsoMu,
                }
 

--- a/lib/EnsoMetricsLib.py
+++ b/lib/EnsoMetricsLib.py
@@ -278,7 +278,7 @@ def EnsoAlphaSwr(sstfile, swrfile, sstname, swrname, sstbox, swrbox, timebounds=
     return alphaSwrMetric
 
 
-def EnsoAlpha(sstfile, thffile, sstname, thfname, sstbox, thfbox, timebounds=None, frequency=None, mintimesteps=None):
+def EnsoAlphaThf(sstfile, thffile, sstname, thfname, sstbox, thfbox, timebounds=None, frequency=None, mintimesteps=None):
     """
     The EnsoAlpha() function computes the regression of 'thfbox' thfA (total heat flux anomalies) over 'sstbox' sstA
     (usually the regression of nino3 thfA over nino3 sstA)

--- a/lib/EnsoMetricsLib.py
+++ b/lib/EnsoMetricsLib.py
@@ -507,7 +507,7 @@ def EnsoMu(sstfile, tauxfile, sstname, tauxname, sstbox, tauxbox, timebounds=Non
     # Read file and select the right region
     sst = ReadSelectRegionCheckUnits(sstfile, sstname, 'temperature', box=sstbox, time_bnds=timebounds,
                                      frequency=frequency)
-    taux = ReadSelectRegionCheckUnits(tauxfile, tauxname, 'heat flux', box=tauxbox, time_bnds=timebounds,
+    taux = ReadSelectRegionCheckUnits(tauxfile, tauxname, 'wind stress', box=tauxbox, time_bnds=timebounds,
                                       frequency=frequency)
 
     # Checks if the same time period is used for both variables and if the minimum number of time steps is respected

--- a/lib/EnsoMetricsLib.py
+++ b/lib/EnsoMetricsLib.py
@@ -688,7 +688,7 @@ def EnsoSeasonality(sstfile, sstname, box, timebounds=None, frequency=None, mint
     # Time period
     actualtimebounds = TimeBounds(sst)
 
-    # Seasonal ans Spatial average
+    # Seasonal and Spatial average
     sst_NDJ = SeasonalMean(sst, 'NDJ', compute_anom=True)
     sst_MAM = SeasonalMean(sst, 'MAM', compute_anom=True)
 

--- a/lib/EnsoMetricsLib.py
+++ b/lib/EnsoMetricsLib.py
@@ -1,7 +1,7 @@
 # -*- coding:UTF-8 -*-
 from inspect import stack as INSPECTstack
-import numpy.sqrt as NUMPYsqrt
-import numpy.square as NUMPYsquare
+from numpy import sqrt as NUMPYsqrt
+from numpy import square as NUMPYsquare
 
 # ENSO_metrics package functions:
 from EnsoCollectionsLib import defCollection

--- a/lib/EnsoUvcdatToolsLib.py
+++ b/lib/EnsoUvcdatToolsLib.py
@@ -385,8 +385,8 @@ def TimeAnomaliesStd(tab):
     """
     # horizontal average
     tab = cdutil.averager(tab, axis='xy')
-    # removes annual cycle (anomalies with respect to the annual cycle)
-    tab = cdutil.ANNUALCYCLE.departures(tab)
+    ## removes annual cycle (anomalies with respect to the annual cycle)
+    #tab = cdutil.ANNUALCYCLE.departures(tab)
     # computes standard deviation
     std = float(GENUTILstd(tab, weights=None, axis=0, centered=1, biased=1))
     return std

--- a/scripts/PMPdriver_EnsoMetrics.py
+++ b/scripts/PMPdriver_EnsoMetrics.py
@@ -26,7 +26,7 @@ param = ReadOptions()
 # User input option
 #-------------------------------------------------
 mcdict = defCollection(param.metricsCollection)
-metrics = mcdict['list_of_metrics']
+metrics = mcdict['metrics_list']
 
 #=================================================
 # Prepare loop iteration

--- a/scripts/PMPdriver_EnsoMetrics.py
+++ b/scripts/PMPdriver_EnsoMetrics.py
@@ -67,8 +67,7 @@ for mod in models:
     print sstFile
     print tauxFile
   
-    #try:
-    if 1:
+    try:
         for metric in metrics:
 
             print metric
@@ -98,8 +97,9 @@ for mod in models:
                 tmp_dict['input_data'] = [sstFile]
                 enso_stat_dic[mod][metric] = tmp_dict
 
-    #except:
-    #    print 'failed for ', mod
+    except Exception as e: 
+        print 'failed for ', mod
+        print(e)
   
 #=================================================
 #  OUTPUT METRICS TO JSON FILE

--- a/scripts/PMPdriver_EnsoMetrics.py
+++ b/scripts/PMPdriver_EnsoMetrics.py
@@ -15,7 +15,7 @@ from pcmdi_metrics.pcmdi.pmp_parser import PMPParser
 
 from EnsoMetrics.EnsoCollectionsLib import defCollection 
 from EnsoMetrics.EnsoMetricsLib import EnsoAlphaLhf, EnsoAlphaLwr, EnsoAlphaSwr, EnsoAlphaThf, EnsoAmpl, EnsoMu, EnsoRMSE, EnsoSeasonality
-from EnsoMetrics.pmpParser import ReadOptions
+from pmpParser import ReadOptions
 
 #=================================================
 # Collect user defined options

--- a/scripts/PMPdriver_EnsoMetrics.py
+++ b/scripts/PMPdriver_EnsoMetrics.py
@@ -68,8 +68,7 @@ for mod in models:
     print sstFile
     print tauxFile
   
-    #try:
-    if 1:
+    try:
         for metric in metrics:
 
             print metric
@@ -99,9 +98,9 @@ for mod in models:
                 tmp_dict['input_data'] = [sstFile]
                 enso_stat_dic[mod][metric] = tmp_dict
 
-    #except Exception as e: 
-    #    print 'failed for ', mod
-    #    print(e)
+    except Exception as e: 
+        print 'failed for ', mod
+        print(e)
   
 #=================================================
 #  OUTPUT METRICS TO JSON FILE

--- a/scripts/PMPdriver_EnsoMetrics.py
+++ b/scripts/PMPdriver_EnsoMetrics.py
@@ -28,6 +28,8 @@ param = ReadOptions()
 mcdict = defCollection(param.metricsCollection)
 metrics = mcdict['metrics_list']
 
+metrics.pop('EnsoMu') ### TEST
+metrics.pop('EnsoSeasonality') ### TEST
 #=================================================
 # Prepare loop iteration
 #-------------------------------------------------
@@ -67,7 +69,8 @@ for mod in models:
     print sstFile
     print tauxFile
   
-    try:
+    #try:
+    if 1:
         for metric in metrics:
 
             print metric
@@ -97,9 +100,9 @@ for mod in models:
                 tmp_dict['input_data'] = [sstFile]
                 enso_stat_dic[mod][metric] = tmp_dict
 
-    except Exception as e: 
-        print 'failed for ', mod
-        print(e)
+    #except Exception as e: 
+    #    print 'failed for ', mod
+    #    print(e)
   
 #=================================================
 #  OUTPUT METRICS TO JSON FILE

--- a/scripts/PMPdriver_EnsoMetrics.py
+++ b/scripts/PMPdriver_EnsoMetrics.py
@@ -29,7 +29,6 @@ mcdict = defCollection(param.metricsCollection)
 metrics = mcdict['metrics_list']
 
 metrics.pop('EnsoMu') ### TEST
-metrics.pop('EnsoSeasonality') ### TEST
 #=================================================
 # Prepare loop iteration
 #-------------------------------------------------

--- a/scripts/PMPdriver_EnsoMetrics.py
+++ b/scripts/PMPdriver_EnsoMetrics.py
@@ -67,38 +67,39 @@ for mod in models:
     print sstFile
     print tauxFile
   
-    try:
+    #try:
+    if 1:
         for metric in metrics:
 
             print metric
 
             if metric == 'EnsoAmpl':
-                nBox = mcdict['dict_of_regions'][metric]['sst']
+                nBox = mcdict['metrics_list'][metric]['regions']['sst']
                 tmp_dict = EnsoAmpl(sstFile, sstName, nBox)
                 tmp_dict['input_data'] = [sstFile]
                 enso_stat_dic[mod][metric] = tmp_dict
 
             elif metric == 'EnsoSeasonality':
-                nBox = mcdict['dict_of_regions'][metric]['sst']
+                nBox = mcdict['metrics_list'][metric]['regions']['sst']
                 tmp_dict = EnsoSeasonality(sstFile, sstName, nBox)
                 tmp_dict['input_data'] = [sstFile]
                 enso_stat_dic[mod][metric] = tmp_dict
 
             elif metric == 'EnsoMu':
-                sstBox = mcdict['dict_of_regions'][metric]['sst']
-                tauxBox = mcdict['dict_of_regions'][metric]['taux']
+                sstBox = mcdict['metrics_list'][metric]['regions']['sst']
+                tauxBox = mcdict['metrics_list'][metric]['regions']['taux']
                 tmp_dict = EnsoMu(sstFile, tauxFile, sstName, tauxName, sstBox, tauxBox)
                 tmp_dict['input_data'] = [sstFile, tauxFile]
                 enso_stat_dic[mod][metric] = tmp_dict
 
             elif metric == 'EnsoRMSE' and mod != 'obs':
-                nBox = mcdict['dict_of_regions'][metric]['sst']
+                nBox = mcdict['metrics_list'][metric]['regions']['sst']
                 tmp_dict = EnsoRMSE(sstFile, sstName, param.sstObsPath, param.sstNameObs, nBox)
                 tmp_dict['input_data'] = [sstFile]
                 enso_stat_dic[mod][metric] = tmp_dict
 
-    except:
-        print 'failed for ', mod
+    #except:
+    #    print 'failed for ', mod
   
 #=================================================
 #  OUTPUT METRICS TO JSON FILE

--- a/scripts/my_Param.py
+++ b/scripts/my_Param.py
@@ -42,4 +42,3 @@ outnamejson = 'test.json'
 #-------------------------------------------------
 # Metrics Collection
 metricsCollection = 'MC1'
-#metrics = ['EnsoAmpl', 'EnsoMu']

--- a/scripts/test.json
+++ b/scripts/test.json
@@ -7,53 +7,57 @@
                 "input_data": [
                     "/work/cmip5/historical/atm/mo/ts/cmip5.IPSL-CM5A-LR.historical.r1i1p1.mo.atm.Amon.ts.ver-1.latestX.xml"
                 ],
-                "method": "Standard deviation of SSTA in nino3",
+                "method": "Standard deviation of nino3 sstA",
                 "name": "ENSO amplitude",
                 "nyears": 156,
-                "ref": "Using CDAT std dev calculation",
-                "units": "C",
-                "value": 0.814021237461244,
-                "value_error": 0.06517385895640071
-            },
-            "EnsoMu": {
-                "input_data": [
-                    "/work/cmip5/historical/atm/mo/ts/cmip5.IPSL-CM5A-LR.historical.r1i1p1.mo.atm.Amon.ts.ver-1.latestX.xml",
-                    "/work/cmip5/historical/atm/mo/tauu/cmip5.IPSL-CM5A-LR.historical.r1i1p1.mo.atm.Amon.tauu.ver-1.latestX.xml"
-                ],
-                "method": "Regression of nino4 tauxA over nino3 sstA",
-                "name": "Bjerknes feedback (mu)",
-                "nonlinearity": 1.2092940838385169,
-                "nonlinearity_error": 0.7677049506664659,
-                "nyears": 156,
                 "ref": "Using CDAT regression calculation",
-                "units": "10-3 N/m2/C",
-                "value": 4.134103621480406,
-                "value_error": 0.15967254543437304
+                "time_frequency": null,
+                "time_period": [
+                    "1850-1-16 12:0:0.0",
+                    "2005-12-16 12:0:0.0"
+                ],
+                "units": "C",
+                "value": 1.0905825144251295,
+                "value_error": 0.0873164823035029
             },
             "EnsoRMSE": {
                 "input_data": [
                     "/work/cmip5/historical/atm/mo/ts/cmip5.IPSL-CM5A-LR.historical.r1i1p1.mo.atm.Amon.ts.ver-1.latestX.xml"
                 ],
-                "method": "Spatial root mean square error SST in tropical_pacific",
+                "method": "Spatial root mean square error of tropical_pacific sst",
                 "name": "ENSO RMSE",
                 "nyears_model": 156,
-                "nyears_obs": 156,
+                "nyears_observations": 142,
                 "ref": "Using CDAT regriding and rms (uncentered and biased) calculation",
+                "time_frequency": null,
+                "time_period_model": [
+                    "1850-1-16 12:0:0.0",
+                    "2005-12-16 12:0:0.0"
+                ],
+                "time_period_observations": [
+                    "1870-1-1 0:0:0.0",
+                    "2012-11-1 0:0:0.0"
+                ],
                 "units": "C",
-                "value": 1.414184534215217,
+                "value": 1.4141848118311606,
                 "value_error": null
             },
             "EnsoSeasonality": {
                 "input_data": [
                     "/work/cmip5/historical/atm/mo/ts/cmip5.IPSL-CM5A-LR.historical.r1i1p1.mo.atm.Amon.ts.ver-1.latestX.xml"
                 ],
-                "method": "Ratio between NDJ and MAM standard deviation of SSTA in nino3",
+                "method": "Ratio between NDJ and MAM standard deviation nino3 sstA",
                 "name": "ENSO Seasonality",
                 "nyears": 156,
                 "ref": "Using CDAT std dev calculation",
+                "time_frequency": null,
+                "time_period": [
+                    "1850-1-16 12:0:0.0",
+                    "2005-12-16 12:0:0.0"
+                ],
                 "units": "",
-                "value": 0.9693193023889148,
-                "value_error": 24.252579799545586
+                "value": 0.9693193023889142,
+                "value_error": 0.15546525512529213
             }
         },
         "obs": {
@@ -61,40 +65,35 @@
                 "input_data": [
                     "/clim_obs/obs/ocn/mo/tos/UKMETOFFICE-HadISST-v1-1/130122_HadISST_sst.nc"
                 ],
-                "method": "Standard deviation of SSTA in nino3",
+                "method": "Standard deviation of nino3 sstA",
                 "name": "ENSO amplitude",
                 "nyears": 142,
-                "ref": "Using CDAT std dev calculation",
-                "units": "C",
-                "value": 0.7868009320493219,
-                "value_error": 0.06602686748662509
-            },
-            "EnsoMu": {
-                "input_data": [
-                    "/clim_obs/obs/ocn/mo/tos/UKMETOFFICE-HadISST-v1-1/130122_HadISST_sst.nc",
-                    "/clim_obs/obs/atm/mo/tauu/ERAINT/tauu_ERAINT_198901-200911.nc"
-                ],
-                "method": "Regression of nino4 tauxA over nino3 sstA",
-                "name": "Bjerknes feedback (mu)",
-                "nonlinearity": 8.265980123765656,
-                "nonlinearity_error": 3.909543765482881,
-                "nyears": 20,
                 "ref": "Using CDAT regression calculation",
-                "units": "10-3 N/m2/C",
-                "value": 14.488138436445253,
-                "value_error": 0.8765541247651075
+                "time_frequency": null,
+                "time_period": [
+                    "1870-1-1 0:0:0.0",
+                    "2012-11-1 0:0:0.0"
+                ],
+                "units": "C",
+                "value": 1.200657284742205,
+                "value_error": 0.10075692110587782
             },
             "EnsoSeasonality": {
                 "input_data": [
                     "/clim_obs/obs/ocn/mo/tos/UKMETOFFICE-HadISST-v1-1/130122_HadISST_sst.nc"
                 ],
-                "method": "Ratio between NDJ and MAM standard deviation of SSTA in nino3",
+                "method": "Ratio between NDJ and MAM standard deviation nino3 sstA",
                 "name": "ENSO Seasonality",
                 "nyears": 142,
                 "ref": "Using CDAT std dev calculation",
+                "time_frequency": null,
+                "time_period": [
+                    "1870-1-1 0:0:0.0",
+                    "2012-11-1 0:0:0.0"
+                ],
                 "units": "",
-                "value": 1.639115499257348,
-                "value_error": 39.133772014224135
+                "value": 1.6391154992573456,
+                "value_error": 0.27558994376214146
             }
         }
     },
@@ -106,9 +105,9 @@
     ],
     "json_version": 3.0,
     "provenance": {
-        "commandLine": "./PMPdriver_EnsoMetrics.py -p my_Param.py",
+        "commandLine": "PMPdriver_EnsoMetrics.py -p my_Param.py",
         "conda": {
-            "DefaultEnvironment": "/export_backup/lee1043/anaconda2/envs/pmp_nightly",
+            "DefaultEnvironment": "/export_backup/lee1043/anaconda2/envs/pmp_nightly_20171126",
             "IsPrivate": "False",
             "Platform": "linux-64",
             "PythonVersion": "2.7.13.final.0",
@@ -117,7 +116,7 @@
             "buildVersion": "not installed",
             "envVersion": "4.3.24"
         },
-        "date": "2017-10-12 10:36:21",
+        "date": "2017-11-26 14:02:16",
         "openGL": {
             "GLX": {
                 "client": {},
@@ -130,25 +129,25 @@
             "PMP": "1.1.2.2017.06.30.19.40.66ce8fec99c4e1d404dc0e5f25d4e6f8e6339f66",
             "PMPObs": null,
             "blas": null,
-            "cdms": "2.12",
-            "cdtime": "2.12",
-            "cdutil": "2.12",
+            "cdms": "2.12.2017.11.16.19.48.f36649030673df4c29ab183af91f9cb4a0819240",
+            "cdtime": "2017.11.15",
+            "cdutil": "2.12.2017.11.16.21.46.e717f782e07d0a187f2b616a408103af20ceb57f",
             "clapack": "3.2.1",
             "esmf": "7.0.0",
             "esmpy": "7.0.0",
-            "genutil": "2.12",
+            "genutil": "2017.11.15",
             "lapack": "3.6.1",
-            "matplotlib": "2.0.2",
+            "matplotlib": "2.1.0",
             "mesalib": null,
             "numpy": "1.13.1",
-            "python": "2.7.13",
-            "vcs": "2.12.2017.09.13.00.29.5669624a25139ad2e19e4af8b921d0571338375d",
+            "python": "2.7.14",
+            "vcs": "2.12.2017.11.17.16.06.e6137d6f0f6df7e5b673b0e6cbc56c21b3694f72",
             "vtk": "7.1.0.2.12"
         },
         "platform": {
             "Name": "crunchy.llnl.gov",
             "OS": "Linux",
-            "Version": "2.6.32-696.3.1.el6.x86_64"
+            "Version": "2.6.32-696.13.2.el6.x86_64"
         },
         "userId": "lee1043"
     }


### PR DESCRIPTION
- Adjust PMP driver code to make it run with @yyplanton 's updated code

- Bug fix for @yyplanton , which includes:
1. fixing mismatched function name: replace `EnsoAlpha` to `EnsoAlphaThf`
2. Correct required variables for 'EnsoMu' and 'EnsoAlphaSwr'
3. `import` statement where importing specific part of numpy

- Some parts need to be considered:
1. I was not able to run `EnsoMu` part since two OBSs (sst, taux) do not have matching period. Previously I inserted the period correction part in the code, but we decided not to do so in last communication.
2. Removing annual cycle need to be moved "BEFORE" getting seasonal mean. 
 
- Confirmed `value_error` for `EnsoRMSE` and `EnsoSeasonality` have reasonable values (previously it was too large. Shown by comparing `test.json`)